### PR TITLE
_build_method variable clarification, more comment formating

### DIFF
--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -11,8 +11,8 @@ module Asynchronize
       #   - The new methods wrap the old method within Thread.new.
       #   - Subsequent calls only add methods to the existing Module.
       #
-      # @param methods [Symbol] The methods to be asynchronized.
-      # @example To add any number of methods to be asynchronized.
+      #   @param methods [Symbol] The methods to be asynchronized.
+      #   @example To add any number of methods to be asynchronized.
       #   asynchronize :method1, :method2, :methodn
       #
       def self.asynchronize(*methods)
@@ -38,8 +38,8 @@ module Asynchronize
   #   Always defines each given method unless it is already defined on obj;
   #   in that case, it will continue to define the remainder of the methods.
   #
-  # @param methods [Array<Symbol>] The methods to be created.
-  # @param obj [Object] The object for the methods to be created on.
+  #   @param methods [Array<Symbol>] The methods to be created.
+  #   @param obj [Object] The object for the methods to be created on.
   #
   private
   def self._define_methods_on_object(methods, obj)
@@ -49,12 +49,14 @@ module Asynchronize
     end
   end
 
+  ##
   # Always builds the exact same proc. Placed into a named method for clarity.
+  #
   def self._build_method
     return Proc.new do |*args, &block|
-      return Thread.new(args, block) do |targs, tblock|
-        Thread.current[:return_value] = super(*targs)
-        tblock.call(Thread.current[:return_value]) if tblock
+      return Thread.new(args, block) do |thread_args, thread_block|
+        Thread.current[:return_value] = super(*thread_args)
+        thread_block.call(Thread.current[:return_value]) if thread_block
       end
     end
   end


### PR DESCRIPTION
`tblock` & `targs` not very descriptive ... wasn't sure if it was "temporary block" or "the block referring to the Thread" ... from code guessing it's the later.

Could easily be ` block_2` & `arg_2` which would be more expressive than `t<var>` format.

If nothing else could easily just be `t_<var>` versus `t<var>` & still clarify.