### PR TITLE
Version 0.3.0 Release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ rvm:
   - 2.5.1
   - 2.3
   - jruby-9.1.13.0
+  - rbx-3
 git:
   depth: false
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 language: ruby
 rvm:
   - 2.5.1
-  - 2.2.2
+  - 2.3
   - jruby-9.1.13.0
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: ruby
 rvm:
   - 2.5.1
   - 2.2.2
+  - jruby-9.1.13.0
 git:
   depth: false
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ env:
     - CC_TEST_REPORTER_ID=5779741f84b94f962138194592b1d6a3036b6b49ae0b800c4d75fea1ef4460c0
 language: ruby
 rvm:
-  - 2.5.1
+  - 2.5
   - 2.3
-  - jruby-9.1.13.0
+  - jruby-9.1
   - rbx-3
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 language: ruby
 rvm:
   - 2.5.1
-  - 2.3
+  - 2.2
   - jruby-9.1.13.0
 git:
   depth: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ env:
 language: ruby
 rvm:
   - 2.5.1
-  - 2.2
+  - 2.3
   - jruby-9.1.13.0
 git:
   depth: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,5 @@
 # frozen_string_literal: true
 
-source "https://rubygems.org"
+source :rubygems
 
-git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
-
-gem 'rake', groups: [:dev, :test]
-gem 'simplecov', group: :test
-gem 'minitest', group: :test
-gem 'pry', group: :dev
+gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,14 @@
+PATH
+  remote: .
+  specs:
+    asynchronize (0.3.0)
+
 GEM
-  remote: https://rubygems.org/
+  remote: http://rubygems.org/
   specs:
     coderay (1.1.2)
     docile (1.3.1)
+    ffi (1.9.25)
     ffi (1.9.25-java)
     json (2.1.0)
     json (2.1.0-java)
@@ -29,10 +35,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  minitest
-  pry
-  rake
-  simplecov
+  asynchronize!
+  minitest (~> 5.11)
+  pry (~> 0.11)
+  rake (~> 12.3)
+  simplecov (~> 0.16)
 
 BUNDLED WITH
    1.16.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     coderay (1.1.2)
     docile (1.3.1)
-    ffi (1.9.24-java)
+    ffi (1.9.25-java)
     json (2.1.0)
     json (2.1.0-java)
     method_source (0.9.0)

--- a/asynchronize.gemspec
+++ b/asynchronize.gemspec
@@ -1,12 +1,15 @@
 require 'date'
+code_repo = 'https://github.com/kennycoc/asynchronize'
 
 Gem::Specification.new do |s|
   s.name = 'asynchronize'
-  s.version = '0.2.1'
+  s.version = '0.3.0'
   s.date = Date.today.to_s
-  s.summary = 'Easily make multiple methods asynchronous with one line of code.'
-  s.description = 'Take any synchronous method, and run it asynchronously, ' +
-    'without cluttering your code with repetetive boilerplate.'
+  s.summary = 'A declarative syntax for creating threads.'
+  s.description = %w{Sometimes you just want a regular thread without the
+                    overhead of a whole new layer of abstraction.
+                    Asynchronize provides a declarative syntax to wrap any
+                    method in a Thread.}.join(' ')
   s.author = 'Kenneth Cochran'
   s.email = 'kenneth.cochran101@gmail.com'
   s.files = [
@@ -20,6 +23,9 @@ Gem::Specification.new do |s|
     'spec/spec.rb',
     'spec/minitest_helper.rb'
   ]
-  s.homepage = 'https://github.com/kennycoc/asynchronize'
+  s.required_ruby_version = '>= 2.3'
+  s.post_install_message = 'Making something cool with asynchronize? ' +
+                           'Let me know at ' + code_repo + '!!'
+  s.homepage = code_repo
   s.license = 'MIT'
 end

--- a/asynchronize.gemspec
+++ b/asynchronize.gemspec
@@ -28,7 +28,8 @@ Gem::Specification.new do |s|
                            'Let me know at ' + code_repo
   s.homepage = code_repo
   s.license = 'MIT'
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'minitest'
-  s.add_development_dependency 'simplecov'
+  s.add_development_dependency 'rake', '~> 12.3'
+  s.add_development_dependency 'minitest', '~> 5.11'
+  s.add_development_dependency 'simplecov', '~> 0.16'
+  s.add_development_dependency 'pry', '~> 0.11'
 end

--- a/asynchronize.gemspec
+++ b/asynchronize.gemspec
@@ -25,7 +25,10 @@ Gem::Specification.new do |s|
   ]
   s.required_ruby_version = '>= 2.3'
   s.post_install_message = 'Making something cool with asynchronize? ' +
-                           'Let me know at ' + code_repo + '!!'
+                           'Let me know at ' + code_repo
   s.homepage = code_repo
   s.license = 'MIT'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'minitest'
+  s.add_development_dependency 'simplecov'
 end

--- a/asynchronize.gemspec
+++ b/asynchronize.gemspec
@@ -2,7 +2,7 @@ require 'date'
 
 Gem::Specification.new do |s|
   s.name = 'asynchronize'
-  s.version = '0.2.0'
+  s.version = '0.2.1'
   s.date = Date.today.to_s
   s.summary = 'Easily make multiple methods asynchronous with one line of code.'
   s.description = 'Take any synchronous method, and run it asynchronously, ' +

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -26,9 +26,7 @@ module Asynchronize
       def self.asynchronize(*methods)
         return if methods.empty?
         async_container = Asynchronize._get_container_for(self)
-        async_container.instance_eval do
-          Asynchronize._define_methods_on_object(methods, self)
-        end
+        Asynchronize._define_methods_on_object(methods, async_container)
       end
     end
   end

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -5,8 +5,8 @@ module Asynchronize
       ##
       # Call to asynchronize a method.
       #
-      #   Calling this does two things
-      #   1. Creates and prepends a module named class + Asynchronized
+      #   This does two things
+      #   1. Creates and prepends a module named "<className> + Asynchronized"
       #   2. Defines each of the passed methods on that module.
       #
       #   - The new methods wrap the old method within Thread.new.

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -26,8 +26,7 @@ module Asynchronize
         @methods_to_async.merge(methods.map {|m| m.hash})
         methods.each do |method|
           # If it's not defined yet, we'll get it with method_added
-          next unless method_defined?(method)
-          Asynchronize.create_new_method(method, self)
+          Asynchronize.create_new_method(method, self) if method_defined?(method)
         end
       end
 

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -17,6 +17,7 @@ module Asynchronize
       #   asynchronize :method1, :method2, :methodn
       #
       def self.asynchronize(*methods)
+        return if methods.empty?
         async_container = Asynchronize._get_container_for(self)
         async_container.instance_eval do
           Asynchronize._define_methods_on_object(methods, self)

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -1,3 +1,8 @@
+##
+# Include this module to allow a declarative syntax for defining asynch methods
+#
+#   Defines only one method on the including class: `asynchronize`
+#
 module Asynchronize
   def self.included(base)
     base.class_eval do
@@ -9,8 +14,10 @@ module Asynchronize
       #   2. Scopes that module to the calling class.
       #   3. Defines each of the passed methods on that module.
       #
+      #   Additional notes:
       #   - The new methods wrap the old method within Thread.new.
       #   - Subsequent calls only add methods to the existing Module.
+      #   - Will silently fail if the method has already been asynchronized
       #
       # @param methods [Symbol] The methods to be asynchronized.
       # @example To add any number of methods to be asynchronized.

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -17,7 +17,7 @@ module Asynchronize
       #
       def self.asynchronize(*methods)
         # require 'pry'; binding.pry
-        module_name = self.name.split('::')[-1] + 'Asynchronized'
+        module_name = self.name.split('::').last + 'Asynchronized'
         if const_defined?(module_name)
           async_container = const_get(module_name)
         else
@@ -40,11 +40,12 @@ module Asynchronize
   #
   # @param methods [Array<Symbol>] The methods to be created.
   # @param obj [Object] The object for the methods to be created on.
+  #
   private
   def self._define_methods_on_object(methods, obj)
     methods.each do |method|
       next if obj.methods.include?(method)
-      obj.define_method(method, _build_method)
+      obj.send(:define_method, method, _build_method)
     end
   end
 

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -2,81 +2,46 @@ module Asynchronize
   require 'set'
   def self.included(base)
     base.class_eval do
-      # The methods we have already asynchronized
-      @asynced_methods = Set.new
-      # The methods that should be asynchronized.
-      @methods_to_async = Set.new
-      # Originally used a single value here, but that's not thread safe.
-      # ...Though you probably have other problems if you have multiple
-      # threads adding methods to your class.
-      @methods_asyncing = Set.new
-
       ##
       # Call to asynchronize a method.
-      #   That method will be added to a list of methods to asynchronize.
-      #   If the method already exists, it will be redefined to an asynchronous
-      #   version. If it does not, method_missing will redefine it when it does.
-      #   If the method is redefined afterwards, method_missing will also
-      #   asynchronize that version.
+      #
+      #   Calling this does two things
+      #   1. Creates and prepends a module named class + Asynchronized
+      #   2. Defines each of the passed methods on that module.
+      #
+      #   - The new methods wrap the old method within Thread.new.
+      #   - Subsequent calls only add methods to the existing Module.
       #
       # @param methods [Symbol] The methods to be asynchronized.
       # @example To add any number of methods to be asynchronized.
       #   asynchronize :method1, :method2, :methodn
+      #
       def self.asynchronize(*methods)
-        @methods_to_async.merge(methods.map {|m| m.hash})
-        methods.each do |method|
-          # If it's not defined yet, we'll get it with method_added
-          Asynchronize.create_new_method(method, self) if method_defined?(method)
+        module_name = self.name.split('::')[-1] + 'Asynchronized'
+        if const_defined?(module_name)
+          async_container = const_get(module_name)
+        else
+          async_container = const_set(module_name, Module.new)
+          prepend async_container
+        end
+
+        async_container.instance_eval do
+          Asynchronize._define_methods_on_object(methods, self)
         end
       end
-
-      # Save the old method_added so we don't overwrite it.
-      if self.methods.include?(:method_added)
-        singleton_class.send(:alias_method, :old_method_added, :method_added)
-        singleton_class.send(:undef_method, :method_added)
-      end
-
-      ##
-      # Will asynchronize a method if it has not been asynchronized already, and
-      #   it is in the list of methods to asynchronize. If method missing was
-      #   already defined, it will call the previous method_missing before
-      #   anything else Ruby calls this automatically when defining a method; it
-      #   should not be called directly.
-      def self.method_added(method)
-        # Return if this is an inherited class that hasn't included asynchronize
-        return if @methods_asyncing.nil?
-        # Return if we're already processing this method
-        return if @methods_asyncing.include?(method.hash)
-        @methods_asyncing.add(method.hash)
-        self.old_method_added(method) if self.methods.include?(:old_method_added)
-        return unless @methods_to_async.include?(method.hash)
-        # This will delete from @methods_asyncing
-        Asynchronize.create_new_method(method, self)
-      end
-    end
-  end
-
-  ##
-  # Responsible for actually creating the new methods and removing the old.
-  def self.create_new_method(method, klass)
-    klass.instance_eval do
-      old_method = instance_method(method)
-      return if @asynced_methods.include?(old_method.hash)
-      undef_method(method)
-
-      @methods_asyncing.add(method.hash)
-      define_method(method, Asynchronize._build_new_method(old_method))
-      @methods_asyncing.delete(method.hash)
-      @asynced_methods.add(instance_method(method).hash)
     end
   end
 
   private
-  def self._build_new_method(old_method)
-    return Proc.new do |*args, &block|
-      return Thread.new(old_method, args, block) do |told_method, targs, tblock|
-        Thread.current[:return_value] = told_method.bind(self).call(*targs)
-        tblock.call(Thread.current[:return_value]) unless tblock.nil?
+  def self._define_methods_on_object(methods, obj)
+    methods.each do |method|
+      next if obj.methods.include?(method)
+      obj.define_method(method) do |*args, &block|
+
+        return Thread.new(args, block) do |targs, tblock|
+          Thread.current[:return_value] = super(*targs)
+          tblock.call(Thread.current[:return_value]) if tblock
+        end
       end
     end
   end

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -44,12 +44,12 @@ module Asynchronize
   def self._define_methods_on_object(methods, obj)
     methods.each do |method|
       next if obj.methods.include?(method)
-      obj.define_method(method, _build_thread)
+      obj.define_method(method, _build_method)
     end
   end
 
   # Always builds the exact same proc. Placed into a named method for clarity.
-  def self._build_thread
+  def self._build_method
     return Proc.new do |*args, &block|
       return Thread.new(args, block) do |targs, tblock|
         Thread.current[:return_value] = super(*targs)

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -32,12 +32,19 @@ module Asynchronize
     end
   end
 
+  ##
+  # Defines an asynchronous wrapping method with the given name on an object.
+  #
+  #   Always defines each method unless that method is already defined on obj;
+  #   in that case, it will continue to define the remainder of the methods.
+  #
+  # @param methods [Array<Symbol>] The methods to be created.
+  # @param obj [Object] The object for the methods to be created on.
   private
   def self._define_methods_on_object(methods, obj)
     methods.each do |method|
       next if obj.methods.include?(method)
       obj.define_method(method) do |*args, &block|
-
         return Thread.new(args, block) do |targs, tblock|
           Thread.current[:return_value] = super(*targs)
           tblock.call(Thread.current[:return_value]) if tblock

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -64,27 +64,12 @@ module Asynchronize
   #   - If the container module is not defined, create, prepend, and return it.
   #
   def self.get_container_for(obj)
-    module_name = get_container_name(obj.name)
-
-    if obj.const_defined?(module_name) 
-      async_container = obj.const_get(module_name)
+    if obj.const_defined?('Asynchronized')
+      return obj.const_get('Asynchronized')
     else
-      async_container = obj.const_set(module_name, Module.new)
+      async_container = obj.const_set('Asynchronized', Module.new)
       obj.prepend async_container
+      return async_container
     end
-    
-    return async_container # required return as prepend is last operation
-  end
-  
-  
-  ##
-  # Get Container Name
-  #  
-  #   Does two things
-  #   1. Trims all but the last child on the namespace
-  #   2. Appends 'Asynchronized'
-  #
-  def self.get_container_name(name)
-    name = name.split('::').last + 'Asynchronized'
   end
 end

--- a/lib/asynchronize.rb
+++ b/lib/asynchronize.rb
@@ -16,7 +16,6 @@ module Asynchronize
       #   asynchronize :method1, :method2, :methodn
       #
       def self.asynchronize(*methods)
-        # require 'pry'; binding.pry
         async_container = Asynchronize.get_container_for(self)
         async_container.instance_eval do
           Asynchronize._define_methods_on_object(methods, self)
@@ -25,22 +24,14 @@ module Asynchronize
     end
   end
 
-  ##
-  # Defines an asynchronous wrapping method with the given name on an object.
-  #
-  #   Always defines each given method unless it is already defined on obj;
-  #   in that case, it will continue to define the remainder of the methods.
-  #
-  # @param methods [Array<Symbol>] The methods to be created.
-  # @param obj [Object] The object for the methods to be created on.
-  #
   private
-  
   ##
   # Define methods on object
   #
-  #   1. If method already defined, do nothing.
-  #   2. If method does not exist, call to build it on object.
+  #   For each method in the array
+  #
+  #   - If method already defined, go to the next.
+  #   - If method does not exist, create it and go to the next.
   #
   # @param methods [Array<Symbol>] The methods to be bound.
   # @param obj [Object] The object for the methods to be defined on.
@@ -55,7 +46,7 @@ module Asynchronize
   ##
   #  Build Method
   #
-  #    Always builds exact same proc. Placed into a named method for clarity.
+  #    The actual method that will be defined when calling asynchronize.
   #
   def self._build_method
     return Proc.new do |*args, &block|
@@ -65,15 +56,13 @@ module Asynchronize
       end
     end
   end
-  
+
   ##
   # Container setup
-  #  
-  #   Does several things
-  #   1. Stores a call for the object name
-  #   2. If module defined, stores it in container
-  #   3. If module not defined, creates it & adds as earliest in the inheritance 
-  #   
+  #
+  #   - If the container module is defined, return it.
+  #   - If the container module is not defined, create, prepend, and return it.
+  #
   def self.get_container_for(obj)
     module_name = get_container_name(obj.name)
 

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ We check for and alias your old method_added. It will be called before
 anything else. Of course, if you define method_added after including
 Asynchronize, you have to do the same and be careful to not overwrite ours!
 
-### Why do I need another framework? My code's bloated enough as it is?
+### Why do I need another gem? My code's bloated enough as it is?
 It's super tiny. Just a light wrapper around the existing language features.
 Seriously, it's just around fifty lines of code. Actually, according to
 [cloc](https://www.npmjs.com/package/cloc) there's almost four times as many

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg)](https://travis-ci.org/kennycoc/asynchronize)
+[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg?branch=dev)](https://travis-ci.org/kennycoc/asynchronize)
 [![Maintainability](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/maintainability)](https://codeclimate.com/github/kennycoc/asynchronize/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/test_coverage)](https://codeclimate.com/github/kennycoc/asynchronize/test_coverage)
 # Asynchronize

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg?branch=master)](https://travis-ci.org/kennycoc/asynchronize)
+[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg)](https://travis-ci.org/kennycoc/asynchronize)
 [![Maintainability](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/maintainability)](https://codeclimate.com/github/kennycoc/asynchronize/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/test_coverage)](https://codeclimate.com/github/kennycoc/asynchronize/test_coverage)
 # Asynchronize

--- a/readme.md
+++ b/readme.md
@@ -126,8 +126,8 @@ knows how to workaround this issue, feel free to submit a pull request.
 We explicitly test against the following versions:
  - Matz Ruby 2.5.1
  - Matz Ruby 2.3.4
- - JRuby 9.1.13
- - Rubinius 3.8.4
+ - JRuby 9.1.13 (language version 2.3.3)
+ - Rubinius 3.105 (language version 2.3.1)
 
 ## License
 MIT

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg?branch=dev)](https://travis-ci.org/kennycoc/asynchronize)
+[![Build Status](https://travis-ci.org/kennycoc/asynchronize.svg?branch=master)](https://travis-ci.org/kennycoc/asynchronize)
 [![Maintainability](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/maintainability)](https://codeclimate.com/github/kennycoc/asynchronize/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/30d40e270a3d7a0775a9/test_coverage)](https://codeclimate.com/github/kennycoc/asynchronize/test_coverage)
 # Asynchronize

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -122,5 +122,14 @@ class BasicSpec < Minitest::Test
         ChildClassTest.new.test.must_equal 6
       end
     end
+
+    describe "when asynchronize is called with no arguments" do
+      it "should not define an Asynchronized container" do
+        Test.asynchronize
+        Test.ancestors.find do |a|
+          a.name.split('::').include? 'Asynchronized'
+        end.must_be_nil
+      end
+    end
   end
 end

--- a/spec/spec.rb
+++ b/spec/spec.rb
@@ -16,29 +16,15 @@ class BasicSpec < Minitest::Test
     end
 
     describe "when we asynchronize a method" do
-      it "should not be the same method" do
-        original_method = Test.instance_method :test
-        Test.asynchronize :test
-        new_method = Test.instance_method(:test)
-        original_method.wont_equal(new_method, "The method was not overwritten")
-      end
       it "should not return a thread unless we asynchronize it" do
         Test.new.test.class.wont_equal(Thread, "The method was not overwritten")
-      end
-      it "should be the same method if we call a second time" do
-        Test.asynchronize :test
-        original_method = Test.instance_method :test
-        Test.asynchronize :test
-        new_method = Test.instance_method :test
-        original_method.must_equal(new_method,
-          "Asynchronized Inception has occurred")
       end
       it "should not throw an error if the specified method does not exist" do
         Test.asynchronize :notamethod
       end
       it "should not create a method if the specified method does not exist" do
         Test.asynchronize :notamethod
-        Test.method_defined?(:notamethod).must_equal false
+        Test.methods(false).wont_include(:notamethod)
       end
       it "should not affect methods on other classes when called before" do
         Test.asynchronize :test
@@ -102,35 +88,6 @@ class BasicSpec < Minitest::Test
           temp = res
         end.join
         temp.must_equal 5, "temp is equal to #{temp}."
-      end
-    end
-
-    describe "when there is an existing method_added" do
-      before do
-        class MethodAddedTest
-          @running = false
-          def self.method_added(method)
-            return if @running
-            @running = true
-            old_method = instance_method(method)
-            undef_method(method)
-            define_method(method) do
-              return old_method.bind(self).call + 1
-            end
-            @running = false
-          end
-          include Asynchronize
-          asynchronize :test
-          def test
-            return 4
-          end
-        end
-      end
-      after do
-        BasicSpec.send(:remove_const, :MethodAddedTest)
-      end
-      it "should call that method_added before, and only once." do
-        MethodAddedTest.new.test.join[:return_value].must_equal 5
       end
     end
 


### PR DESCRIPTION
This release contains significant improvements. The old method of overriding method_added would have slowed down loading of large classes, since it needs to be run on every method that is defined on the class that includes Asynchronize. This version uses `Module#prepend` in order to override the methods.

This does have some trade offs, as we can no longer support Ruby < 2.3. I've changed the required ruby version in the Gem, so users below this version should not receive it.